### PR TITLE
Added Android 13 support

### DIFF
--- a/Helpers/script.js
+++ b/Helpers/script.js
@@ -95,8 +95,6 @@ function prepareKeyRequest(address) {
                     this.ret = args[4];
                     break;
                 case '16.1.0':
-                    this.ret = args[5];
-                    break;
                 case '17.0.0':
                     this.ret = args[5];
                     break;

--- a/Helpers/script.js
+++ b/Helpers/script.js
@@ -97,6 +97,9 @@ function prepareKeyRequest(address) {
                 case '16.1.0':
                     this.ret = args[5];
                     break;
+                case '17.0.0':
+                    this.ret = args[5];
+                    break;
                 default:
                     const message = 'Defaulting to args[4] for PrepareKeyRequest.'
                     send('message_info', new TextEncoder().encode(message));

--- a/README.md
+++ b/README.md
@@ -3,9 +3,14 @@
 Dumper is a Frida script to dump L3 CDMs from any Android device.
 
 ## ** IMPORTANT **
-The function parameters can differ between CDM versions. The default is [4] but you may have to change this for your specific version.
+The function parameters can differ between CDM versions. The default is [4] but you may have to change this for your specific version in the [script.js](./Helpers/script.js).
 
-* `CDM_VERSION` can be retrieved using a DRM Info app.
+## Prerequisites
+- Rooted Android device
+- [Installed Frida server on the Android device]((https://frida.re/docs/android/))
+- Installed [platform-tools ADB/Fastboot](https://developer.android.com/studio/releases/platform-tools) on the PC
+- Installed [Python 3](https://www.python.org/downloads/) on the PC
+- `CDM_VERSION` retrieved from the [DRM Info app](https://play.google.com/store/apps/details?id=com.androidfung.drminfo).
 
 ## Requirements:
 Use pip to install the dependencies:
@@ -14,33 +19,51 @@ Use pip to install the dependencies:
 
 ## Usage:
 
-* Enable USB debugging
-* Start frida-server on the device
-* Execute dump_keys.py
-* Start streaming some DRM-protected content
+* Enable USB debugging on the Android device and connect it to the PC
+* [Start frida-server on the Android device](https://frida.re/docs/android/)
+* Execute dump_keys.py on the PC
+* Start streaming some DRM-protected content on the Android device e.g. [Bitmovin](https://bitmovin.com/demos/drm)
 
-The script will hook every function in your 'libwvhidl.so' module by default, effectively brute forcing the private key function name.
+The script will hook every function in your widevine 'libwvhidl.so'/'libwvaidl.so' modules by default, effectively brute forcing the private key function name.
 ```
-python3 .\dump_keys.py [OPTIONS]
-```
-
-You can pass the function name to hook using the `--function-name` argument.
-```
-python3 .\dump_keys.py --function-name 'polorucp'
+python3 dump_keys.py
 ```
 
-The script defaults to `args[4]` if no `--cdm-version` is provided. This will only have an effect if your version is `16.1.0`.
+You can pass the function name to hook using the `--function-name` argument. You can use [this post](https://forum.videohelp.com/threads/404219-How-To-Dump-L3-CDM-From-Android-Device-s-(ONLY-Talk-About-Dumping-L3-CDMS)/page6#post2646150) to retrive it by yourself.
+```
+python3 dump_keys.py --function-name 'polorucp'
+```
+
+The script defaults to `args[4]` if no `--cdm-version` is provided. This will only have an effect if your version is `16.1.0` or `17.0.0`.
 
 ```
-python3 .\dump_keys.py --cdm-version '16.1.0'
+python3 dump_keys.py --cdm-version '16.1.0'
 ```
+
+You can pass the `.so`-module name using the `--function-name` argument. By default it looking in `libwvhidl.so` and `libwvaidl.so` files. It can have multiple values. Its name can change depending on the version and SoC including but not limited to: `libwvaidl.so`, `libwvhidl.so`, `libwvdrmengine.so`, `libwvm.so`, `libdrmwvmplugin.so`[source](https://arxiv.org/abs/2204.09298). You can find your name in the /vendor/lib64/ or /vendor/lib/ directories using ADB shell.
+
+```
+python3 dump_keys.py --module-name 'libwvhidl.so' --module-name 'libwvaidl.so'
+```
+
 
 ## Options:
 ```
     -h, --help                      Print this help text and exit.
     --cdm-version                   The CDM version of the device e.g. '16.1.0'.
     --function-name                 The name of the function to hook to retrieve the private key.
+    --module-name                   The names of the widevine `.so` modules.
 ```
+
+## Scenario:
+1. You've got function names
+2. You've got private key
+3. Client ID extracted
+4. Script closed
+
+After scipt closed you will have next files:
+- `client_id.bin` - 
+- `private_key.pem` - RSA private key
 
 ## Known Working Versions:
 * Android 9
@@ -51,6 +74,8 @@ python3 .\dump_keys.py --cdm-version '16.1.0'
     * CDM 16.0.0
 * Android 12
     * CDM 16.1.0
+* Android 13
+    * CDM 17.0.0
 
 ## Temporary disabling L1 to use L3 instead
 A few phone brands let us use the L1 keybox even after unlocking the bootloader (like Xiaomi). In this case, installation of a Magisk module called [liboemcrypto-disabler](https://github.com/umylive/liboemcrypto-disabler) is necessary.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The script defaults to `args[4]` if no `--cdm-version` is provided. This will on
 python3 dump_keys.py --cdm-version '16.1.0'
 ```
 
-You can pass the `.so`-module name using the `--function-name` argument. By default it looking in `libwvhidl.so` and `libwvaidl.so` files. It can have multiple values. Its name can change depending on the version and SoC including but not limited to: `libwvaidl.so`, `libwvhidl.so`, `libwvdrmengine.so`, `libwvm.so`, `libdrmwvmplugin.so`[source](https://arxiv.org/abs/2204.09298). You can find your name in the /vendor/lib64/ or /vendor/lib/ directories using ADB shell.
+You can pass the `.so` -module name using the `--module-name` argument. By default it looks in the `libwvhidl.so` and `libwvaidl.so` files. It can have multiple values. Its name can change depending on the version and SoC including but not limited to: `libwvaidl.so`, `libwvhidl.so`, `libwvdrmengine.so`, `libwvm.so`, `libdrmwvmplugin.so`[source](https://arxiv.org/abs/2204.09298). You can find your module name in the /vendor/lib64/ or /vendor/lib/ directories using an ADB shell.
 
 ```
 python3 dump_keys.py --module-name 'libwvhidl.so' --module-name 'libwvaidl.so'
@@ -52,16 +52,16 @@ python3 dump_keys.py --module-name 'libwvhidl.so' --module-name 'libwvaidl.so'
     -h, --help                      Print this help text and exit.
     --cdm-version                   The CDM version of the device e.g. '16.1.0'.
     --function-name                 The name of the function to hook to retrieve the private key.
-    --module-name                   The names of the widevine `.so` modules.
+    --module-name                   The name of the widevine `.so` modules.
 ```
 
 ## Scenario:
-1. You've got function names
-2. You've got private key
+1. You've got the function name
+2. You've got the private key
 3. Client ID extracted
 4. Script closed
 
-After scipt closed you will have next files:
+The following files will be created after a successful dump:
 - `client_id.bin` - 
 - `private_key.pem` - RSA private key
 

--- a/dump_keys.py
+++ b/dump_keys.py
@@ -15,13 +15,20 @@ def main():
     parser = argparse.ArgumentParser(description='Android Widevine L3 dumper.')
     parser.add_argument('--cdm-version', help='The CDM version of the device e.g. \'14.0.0\'', default='14.0.0')
     parser.add_argument('--function-name', help='The name of the function to hook to retrieve the private key.', default='')
+    parser.add_argument('--module-name', 
+        nargs='+',
+        type=str,
+        help='The names of the widevine `.so` modules',
+        default=["libwvaidl.so", "libwvhidl.so"]
+    )
     args = parser.parse_args()
 
     dynamic_function_name = args.function_name
     cdm_version = args.cdm_version
+    module_names = args.module_name
 
     logger = logging.getLogger("main")
-    device = Device(dynamic_function_name, cdm_version)
+    device = Device(dynamic_function_name, cdm_version, module_names)
     logger.info('Connected to %s', device.name)
     logger.info('Scanning all processes')
 
@@ -29,7 +36,7 @@ def main():
         if 'drm' in process.name:
             for library in device.find_widevine_process(process.name):
                 device.hook_to_process(process.name, library)
-    logger.info('Functions Hooked, load the DRM stream test on Bitmovin!')
+    logger.info('Functions hooked, now open the DRM stream test on Bitmovin from your Android device! https://bitmovin.com/demos/drm')
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 frida
-protobuf==3.19.3
+protobuf == 3.19.3
 pycryptodome

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 frida
-protobuf == 3.19.3
+protobuf==3.19.3
 pycryptodome


### PR DESCRIPTION
Pull request:
- Update Device constructor to accept widevine module names
- Improve script compatibility across various devices
- Add command-line option to specify custom module names
- Fix an issue where script would fail if module not found

Successfully tested with Android 13